### PR TITLE
部分mock情况下没有配置url不转发代理服务端问题

### DIFF
--- a/src/mock/index.js
+++ b/src/mock/index.js
@@ -118,14 +118,14 @@ module.exports = function  (app, option) {
           return
         }
       }
-      if(mock[pathname]){
-        var mes=mock[pathname];
-      }else{
-        if(req.originalUrl.indexOf('proxy-api') !== -1){
-          next();
-          return false;
-        }
-        var mes={info:'这个接口没有定意'};
+      if(mock[pathname]) {
+        var mes = mock[pathname];
+      } else if(req.originalUrl.indexOf('proxy-api') !== -1) {
+        next()
+        return false;
+      }else if (activeMock === 'part') {
+        next();
+        return
       }
       res.send(mes.data);
     });


### PR DESCRIPTION
**Issue** 
部分mock情况下，没有配置mock url不自动转发 

**modified**
 没有配置mock url，直接转发代理服务端